### PR TITLE
Added FixedUpdateActiveState to state interface

### DIFF
--- a/Assets/Scripts/StateMachine/IStateMachine.cs
+++ b/Assets/Scripts/StateMachine/IStateMachine.cs
@@ -9,6 +9,7 @@
         void ChangeState(State toState);
         void ChangeState(string toStateName);
         void UpdateActiveState();
+        void FixedUpdateActiveState();
         bool ContainsState(State state);
         bool ContainsState(string stateName);
         bool ContainsState(string stateName, out State foundState);

--- a/Assets/Scripts/StateMachine/StateMachine.cs
+++ b/Assets/Scripts/StateMachine/StateMachine.cs
@@ -123,6 +123,11 @@ namespace Vast.StateMachine {
             ActiveState?.Update();
         }
 
+        /// <summary>Calls FixedUpdateState in the active State.</summary>
+        public void FixedUpdateActiveState() {
+            ActiveState?.FixedUpdate();
+        }
+
         /// <summary>Does the State Machine contain this State?</summary>
         /// <param name="state"></param>
         /// <returns>True or False</returns>


### PR DESCRIPTION
I thought it odd that the interface for State Machines was missing a signature for Fixed Update of the active state. Maybe you had a reason for this?